### PR TITLE
Multiline secrets && prettier empty secrets @hamaxx 

### DIFF
--- a/secretcrypt/__init__.py
+++ b/secretcrypt/__init__.py
@@ -15,6 +15,12 @@ class Secret(object):
     """Represents an encrypted secret that can be decrypted on demand."""
 
     def __init__(self, secret):
+        if len(secret) == 0:
+            # empty secret object
+            self._cached = True
+            self.__plaintext = ''
+            return
+
         tokens = secret.split(':')
         if len(tokens) < 3:
             raise ValueError('Malformed secret "%s"' % secret)

--- a/secretcrypt/encrypt_secret.py
+++ b/secretcrypt/encrypt_secret.py
@@ -2,12 +2,13 @@
 Encrypts secrets. Reads secrets as user input or from standard input.
 
 Usage:
-  encrypt-secret kms [--region=<region_name>] <key_id>
-  encrypt-secret local
-  encrypt-secret plain
-
+  encrypt-secret [options] kms [--region=<region_name>] <key_id>
+  encrypt-secret [options] local
+  encrypt-secret [options] plain
 Options:
+
   --region=<region_name>    AWS Region Name [default: us-east-1]
+  --multiline               Multiline input (read stdin bytes until EOF)
 """
 from __future__ import print_function
 from docopt import docopt
@@ -42,9 +43,14 @@ def encrypt_secret_cmd():
         import plain
         module = plain
 
-    # do not print prompt if input is being piped
-    prompt = 'Enter plaintext: ' if sys.stdin.isatty() else ''
-    plaintext = raw_input(prompt)
+    if arguments['--multiline']:
+        plaintext = sys.stdin.read()
+    else:
+        # do not print prompt if input is being piped
+        if sys.stdin.isatty():
+            print('Enter plaintext: ', file=sys.stderr)
+        plaintext = sys.stdin.readline()
+
     secret = encrypt_secret(module, plaintext, encrypt_params)
     return secret
 

--- a/secretcrypt/kms.py
+++ b/secretcrypt/kms.py
@@ -16,7 +16,7 @@ def _kms_client(region):
 def encrypt(plaintext, region, key_id):
     ciphertext_blob = _kms_client(region).encrypt(
         KeyId=key_id,
-        Plaintext=plaintext.encode('utf-8')
+        Plaintext=plaintext
     )['CiphertextBlob']
     return base64.b64encode(ciphertext_blob), dict(region=region)
 
@@ -24,4 +24,4 @@ def encrypt(plaintext, region, key_id):
 def decrypt(ciphertext, region):
     return _kms_client(region).decrypt(
         CiphertextBlob=base64.b64decode(ciphertext)
-    )['Plaintext'].decode('utf-8')
+    )['Plaintext']

--- a/secretcrypt/local.py
+++ b/secretcrypt/local.py
@@ -44,7 +44,6 @@ def _key_dir():
 
 
 def encrypt(plaintext):
-    plaintext = plaintext.encode('utf-8')
     padding = 16 - len(plaintext) % 16
     plaintext += six.int2byte(padding) * padding
     iv = os.urandom(16)
@@ -61,4 +60,4 @@ def decrypt(ciphertext):
     plaintext = aes.decrypt(ciphertext_blob)
     unpadding = six.byte2int([plaintext[-1]])
     plaintext = plaintext[:-unpadding]
-    return plaintext.decode('utf-8')
+    return plaintext

--- a/secretcrypt/tests/test_kms.py
+++ b/secretcrypt/tests/test_kms.py
@@ -17,7 +17,7 @@ class TestLocal(unittest.TestCase):
 
         self.key = 'mykey'
         self.region = 'myregion'
-        self.plaintext = 'myplaintext'
+        self.plaintext = b'myplaintext'
         self.plaintext_bytes = b'myplaintext'
         self.ciphertext_blob = b'abc'
         self.ciphertext = base64.b64encode(self.ciphertext_blob)

--- a/secretcrypt/tests/test_local.py
+++ b/secretcrypt/tests/test_local.py
@@ -26,7 +26,7 @@ class TestLocal(unittest.TestCase):
 
     @mock.patch('os.makedirs')
     def test_key_created(self, os_makedirs):
-        local.encrypt('abc')
+        local.encrypt(b'abc')
         os_makedirs.assert_called_with(self.tmpdir)
         self.assertTrue(os.path.isfile(self.key_file))
 
@@ -36,10 +36,10 @@ class TestLocal(unittest.TestCase):
         with open(self.key_file) as f:
             with mock.patch.object(six.moves.builtins, 'open') as mock_open:
                 mock_open.return_value = f
-                local.encrypt('abc')
+                local.encrypt(b'abc')
                 mock_open.assert_called_with(self.key_file, 'rb')
 
     def test_encrypt_decrypt(self):
-        plaintext = 'myplaintext'
+        plaintext = b'myplaintext'
         ciphertext, decrypt_params = local.encrypt(plaintext)
         self.assertEqual(plaintext, local.decrypt(ciphertext, **decrypt_params))


### PR DESCRIPTION
- add option to encrypt multiline secrets such as certificates
- prettire empty secrets; `Secret('')` instead of `Secret('plain::')`

pls review @hamaxx 