### PR TITLE
Fix reraise error in decrypt

### DIFF
--- a/secretcrypt/__init__.py
+++ b/secretcrypt/__init__.py
@@ -65,8 +65,8 @@ class StrictSecret(object):
         except Exception as e:
             exc_info = sys.exc_info()
             six.reraise(
+                ValueError,
                 ValueError('Invalid ciphertext "%s", error: %s' % (self._ciphertext, e)),
-                None,
                 exc_info[2]
             )
 


### PR DESCRIPTION
When an exception is raised during decrypt the code that should reraise it currently fails with:

```
  File "/usr/local/lib/python3.7/site-packages/secretcrypt/__init__.py", line 90, in __init__
    self.__plaintext_bytes = StrictSecret(secret).decrypt()
  File "/usr/local/lib/python3.7/site-packages/secretcrypt/__init__.py", line 70, in decrypt
    exc_info[2]
  File "/usr/local/lib/python3.7/site-packages/six.py", line 690, in reraise
    value = tp()
TypeError: 'ValueError' object is not callable
```

The original exception is lost.

As per https://six.readthedocs.io/#six.reraise the first argument should be exc_type, the exception class, not an instance.